### PR TITLE
cleanup test formatting

### DIFF
--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -1,33 +1,26 @@
-using Distributions
-using HMMBase
-using Random
-using Test
-
-Random.seed!(2019)
-
 @testset "< v1.1" begin
     hmm = HMM([0.9 0.1; 0.1 0.9], [Normal(0, 1), Normal(10, 1)])
     z, y = rand(hmm, 2500, seq = true)
-    @test forward(hmm, y, logl = true) == forward(hmm, y, logl = false) == forward(hmm, y)
-    @test backward(hmm, y, logl = true) ==
-          backward(hmm, y, logl = false) ==
+    @test (@test_logs (:warn,) match_mode=:any forward(hmm, y, logl = true)) == (@test_logs (:warn,) match_mode=:any forward(hmm, y, logl = false)) == forward(hmm, y)
+    @test (@test_logs (:warn,) match_mode=:any backward(hmm, y, logl = true)) ==
+          (@test_logs (:warn,) match_mode=:any backward(hmm, y, logl = false)) ==
           backward(hmm, y)
-    @test posteriors(hmm, y, logl = true) ==
-          posteriors(hmm, y, logl = false) ==
+    @test (@test_logs (:warn,) match_mode=:any posteriors(hmm, y, logl = true)) ==
+          (@test_logs (:warn,) match_mode=:any posteriors(hmm, y, logl = false)) ==
           posteriors(hmm, y)
-    @test viterbi(hmm, y, logl = false) == viterbi(hmm, y, logl = true) == z
-    @test likelihoods(hmm, y) == exp.(loglikelihoods(hmm, y))
-    @test likelihoods(hmm, y, logl = true) == loglikelihoods(hmm, y)
+    @test (@test_logs (:warn,) match_mode=:any viterbi(hmm, y, logl = false)) == (@test_logs (:warn,) match_mode=:any viterbi(hmm, y, logl = true)) == z
+    @test (@test_logs (:warn,) match_mode=:any likelihoods(hmm, y)) == exp.(loglikelihoods(hmm, y))
+    @test (@test_logs (:warn,) match_mode=:any likelihoods(hmm, y, logl = true)) == loglikelihoods(hmm, y)
 end
 
 @testset "< v1.0" begin
     hmm = HMM([0.9 0.1; 0.1 0.9], [Normal(0, 1), Normal(10, 1)])
     z, y = rand(hmm, 2500, seq = true)
-    @test n_parameters(hmm) == nparams(hmm)
-    @test log_likelihoods(hmm, y) == loglikelihoods(hmm, y)
-    @test forward_backward(hmm, y) == posteriors(hmm, y)
-    @test messages_forwards(hmm, y) == forward(hmm, y)
-    @test messages_backwards(hmm, y) == backward(hmm, y)
-    @test compute_transition_matrix(z) == gettransmat(z, relabel = true)
-    @test size(rand_transition_matrix(5, 2.0)) == (5, 5)
+    @test (@test_deprecated n_parameters(hmm)) == nparams(hmm)
+    @test (@test_deprecated log_likelihoods(hmm, y)) == loglikelihoods(hmm, y)
+    @test (@test_deprecated forward_backward(hmm, y)) == posteriors(hmm, y)
+    @test (@test_deprecated messages_forwards(hmm, y)) == forward(hmm, y)
+    @test (@test_deprecated messages_backwards(hmm, y)) == backward(hmm, y)
+    @test (@test_deprecated compute_transition_matrix(z)) == gettransmat(z, relabel = true)
+    @test size((@test_deprecated rand_transition_matrix(5, 2.0))) == (5, 5)
 end

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -1,10 +1,3 @@
-using Test
-using HMMBase
-using Distributions
-using Random
-
-Random.seed!(2019)
-
 hmms = [
     HMM([0.9 0.1; 0.1 0.9], [Normal(10, 1), Gamma(1, 1)]),
     HMM([0.9 0.1; 0.1 0.9], [Categorical([0.1, 0.2, 0.7]), Categorical([0.5, 0.5])]),
@@ -46,7 +39,7 @@ hmms = [
 
     # MLE
     if T > 2
-        hmm2, _ = fit_mle(hmm, y, maxiter = 1, display = :iter)
+            hmm2, _ = fit_mle(hmm, y, maxiter = 1)
         @test size(hmm2) == size(hmm)
         @test typeof(hmm2) == typeof(hmm)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,21 @@
-# Low-level, isolated, functions tests.
-include("unit.jl")
+using Test
+using Distributions
+using HMMBase
+using Random
+using JSON
+using LinearAlgebra
 
-# High-level API tests.
-# Ensure that everything works well together, for different kinds of HMMs.
-include("integration.jl")
+using HMMBase: from_dict, issquare
 
-# Test that deprecated methods are still working.
-include("deprecated.jl")
+Random.seed!(2019)
+@testset "All" begin
+    # Low-level, isolated, functions tests.
+    include("unit.jl")
+
+    # High-level API tests.
+    # Ensure that everything works well together, for different kinds of HMMs.
+    include("integration.jl")
+
+    # Test that deprecated methods are still working.
+    include("deprecated.jl")
+end

--- a/test/unit.jl
+++ b/test/unit.jl
@@ -1,14 +1,3 @@
-using Distributions
-using JSON
-using HMMBase
-using LinearAlgebra
-using Test
-using Random
-
-using HMMBase: from_dict, issquare
-
-Random.seed!(2019)
-
 @testset "Base" begin
     hmm1 = HMM([0.9 0.1; 0.1 0.9], [Normal(0, 1), Normal(10, 1)])
     hmm2 = HMM(


### PR DESCRIPTION
Some cleanup to the test suite by
- Wrapping all the tests in one outer `@testset` to group the tests
- Using `@test_deprecated` and `@test_logs` to quiet down some of the output
- Moving all the `using` statements to the `runtests.jl` file

Here's the output of running the tests on this branch:
<img width="255" alt="Screen Shot 2021-02-09 at 5 57 54 PM" src="https://user-images.githubusercontent.com/38324289/107439824-ad80bf00-6b00-11eb-801e-3046a57b9b8f.png">

And here's the current master branch:
<img width="747" alt="Screen Shot 2021-02-09 at 5 58 56 PM" src="https://user-images.githubusercontent.com/38324289/107439832-b40f3680-6b00-11eb-8269-d08d84042d4b.png">
